### PR TITLE
Work with paths config

### DIFF
--- a/test/basics/main.js
+++ b/test/basics/main.js
@@ -1,6 +1,8 @@
 var one = require("one");
+var three = require("three");
 
 module.exports = {
 	name: "basics",
-	one: one
+	one: one,
+	three: three
 };

--- a/test/basics/node_modules/three/main.js
+++ b/test/basics/node_modules/three/main.js
@@ -1,0 +1,1 @@
+module.exports = "real";

--- a/test/basics/node_modules/three/package.json
+++ b/test/basics/node_modules/three/package.json
@@ -1,0 +1,5 @@
+{
+	"name": "three",
+	"version": "1.0.0",
+	"main": "main.js"
+}

--- a/test/basics/package.json
+++ b/test/basics/package.json
@@ -3,6 +3,12 @@
 	"version": "0.0.1",
 	"main": "main.js",
 	"dependencies": {
-		"one": "1.0.0"
+		"one": "1.0.0",
+		"three": "1.0.0"
+	},
+	"system": {
+		"paths": {
+			"three": "three.js"
+		}
 	}
 }

--- a/test/basics/three.js
+++ b/test/basics/three.js
@@ -1,0 +1,1 @@
+module.exports = "fake";


### PR DESCRIPTION
This changes how locate work so that we first call the parent locate so
that we know if there were any unexpected changes (like from a paths
        config). If there were, we shouldn't be overriding those.
